### PR TITLE
Lower limit cap on brightness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 # Auto-configuration
 BRIGHTNESSFILE=$(shell find /sys/class/backlight/*/brightness | head -1)
 MAXVALUE=$(shell find /sys/class/backlight/*/max_brightness | head -1 | xargs cat)
-
+MINVALUE=5
 # version info from git
 REVCNT          := $(shell git rev-list --count master 2>/dev/null)
 ifeq ($(REVCNT),)
@@ -46,6 +46,7 @@ $(BUILD_HOST):
 	@echo "#define BRIGHTNESSFILE \"$(BRIGHTNESSFILE)\"" >> $(BUILD_HOST)
 	@echo "#define MAXVALUE $(MAXVALUE)"                 >> $(BUILD_HOST)
 	@echo "#define VERSION \"$(VERSION)\""               >> $(BUILD_HOST)
+	@echo "#define MINVALUE $(MINVALUE)"               >> $(BUILD_HOST)
 
 $(TARGET): $(BUILD_HOST) $(OBJ)
 	$(CC) $(LFLAGS) -o $@ $(OBJ)

--- a/xbright.c
+++ b/xbright.c
@@ -69,7 +69,10 @@ bright_down(const char *value)
     int offset_value = MAX(atoi(value), 1);
     int cur_value = get_current();
     int new_value = MAX(cur_value - offset_value, 0);
+    if (new_value < MINVALUE) {
+        ERROR("Error: Cant go below 5");
 
+    }
     if (new_value != cur_value) {
         commit_change(new_value);
     }

--- a/xbright.c
+++ b/xbright.c
@@ -71,7 +71,6 @@ bright_down(const char *value)
     int new_value = MAX(cur_value - offset_value, 0);
     if (new_value < MINVALUE) {
         ERROR("Error: Cant go below 5");
-
     }
     if (new_value != cur_value) {
         commit_change(new_value);


### PR DESCRIPTION
xbright is an excellent program, but a problem in bright_down function allowed setting brightness to as low as 0, this is truly undesirable as nobody would want their machine to be at 0 brightness. 
So I added a MINVALUE in Makefile and changed the xbright.c to not go below 5 and show the error. 
I was thinking of integrating libnotify to notify the users as well via alert notification, but that'd probably lead to making it more heavy and dependent. 
Kindly take a look into it and let me know. 
Thank you.